### PR TITLE
Pull request

### DIFF
--- a/lib/soap/property.rb
+++ b/lib/soap/property.rb
@@ -317,17 +317,3 @@ end
 
 
 end
-
-
-# for ruby/1.6.
-unless Enumerable.instance_methods.include?('inject')
-  module Enumerable
-    def inject(init)
-      result = init
-      each do |item|
-	result = yield(result, item)
-      end
-      result
-    end
-  end
-end


### PR DESCRIPTION
On Ruby 1.9 with Rails 3, `Enumerable.instance_methods.include?('inject')` returns false which was causing the inject method to be overridden. This was making my application crash.

We should remove backwards compatibility for Ruby 1.6.
